### PR TITLE
New '--format' flag with options for env and php

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,11 @@ wp salts generate --file=/absolute/path/to/file.php
 ```
 
 This will output the salts to a file. Because the file contains the complete `define()` code the salts will be set by a simple `require` somewhere in your wp-config.php
+
+## Output salts as env vars
+
+```
+wp salts generate --format=env
+```
+
+This will output the salts as shell environment variables. Useful for projects that load configurations from .env files.

--- a/salt-command.php
+++ b/salt-command.php
@@ -8,8 +8,8 @@
 class Salts_Command extends WP_CLI_Command {
 
   /**
-   * Generates salts to STDOUT or to a file
-   * 
+   * Generates salts to STDOUT or to a file.
+   *
    * @when before_wp_load
    *
    * @synopsis [--file=<foo>]
@@ -17,19 +17,19 @@ class Salts_Command extends WP_CLI_Command {
    */
   function generate( $args, $assoc_args ) {
     $api  = 'https://api.wordpress.org/secret-key/1.1/salt/';
-    $data = file_get_contents( $api ); 
+    $data = file_get_contents( $api );
 
     if ( isset( $assoc_args['file'] ) ) {
       $file   = $assoc_args['file'];
       $output = '<?php' . PHP_EOL . PHP_EOL . $data . PHP_EOL;
 
       if ( ! is_writable( $file ) )
-        WP_CLI::error('File is not writable or path is not correct: ' . $file );
+        WP_CLI::error( 'File is not writable or path is not correct: ' . $file );
 
       if ( ! file_put_contents( $file, $output ) )
-        WP_CLI::error('could not write salts to: ' . $file );
+        WP_CLI::error( 'Could not write salts to: ' . $file );
 
-      WP_CLI::success('Added salts to: ' . $file );
+      WP_CLI::success( 'Added salts to: ' . $file );
       return;
     }
 

--- a/salt-command.php
+++ b/salt-command.php
@@ -10,18 +10,30 @@ class Salts_Command extends WP_CLI_Command {
   /**
    * Generates salts to STDOUT or to a file.
    *
-   * @when before_wp_load
+   * ## OPTIONS
    *
-   * @synopsis [--file=<foo>]
+   * [--file=<file>]
+   * : The name of the file to write to. Default outputs to STDOUT.
+   *
+   * [--format=<format>]
+   * : Can be php or env. Defaults to php.
+   *
+   * @when before_wp_load
+   * @synopsis [--file=<file>] [--format=<format>]
    *
    */
   function generate( $args, $assoc_args ) {
-    $api  = 'https://api.wordpress.org/secret-key/1.1/salt/';
-    $data = file_get_contents( $api );
+    $defaults = array(
+      'format' => 'php',
+    );
+    $assoc_args = array_merge( $defaults, $assoc_args );
+
+    $api    = 'https://api.wordpress.org/secret-key/1.1/salt/';
+    $data   = file_get_contents( $api );
+    $output = self::_format_data( $data, $assoc_args['format'] );
 
     if ( isset( $assoc_args['file'] ) ) {
-      $file   = $assoc_args['file'];
-      $output = '<?php' . PHP_EOL . PHP_EOL . $data . PHP_EOL;
+      $file = $assoc_args['file'];
 
       if ( ! is_writable( $file ) )
         WP_CLI::error( 'File is not writable or path is not correct: ' . $file );
@@ -33,7 +45,23 @@ class Salts_Command extends WP_CLI_Command {
       return;
     }
 
-    fwrite( STDOUT, $data );
+    fwrite( STDOUT, $output );
+  }
+
+  private static function _format_data( $data, $format ) {
+    switch ( $format ) {
+      case 'env':
+        $pattern   = "/define\('([A-Z_]+)',\s*'(.+)'\);/";
+        $formatted = "\n\n" . preg_replace($pattern, "$1='$2'", $data) . "\n";
+        break;
+
+      case 'php':
+      default:
+        $formatted = '<?php' . PHP_EOL . PHP_EOL . $data . PHP_EOL;
+        break;
+    }
+
+    return $formatted;
   }
 }
 


### PR DESCRIPTION
Hi. Would you be interested in this new feature? I added a --format flag with an option to convert the salts to environment variables. It doesn't alter the default behavior at all or any of the existing commands, just adds a new option. It's really useful for WordPress frameworks and projects that load their configurations from .env files.

Thanks!
