### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "sebastiaandegeus/wp-cli-salts-command",
   "description": "Manage salts for your WordPress installation",
+  "type": "wp-cli-package",
   "homepage": "https://github.com/sebastiaandegeus/wp-cli-salts-command",
   "license": "MIT",
   "require": {


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567